### PR TITLE
specify files to pack to avoid oclif warning

### DIFF
--- a/commands/publish.js
+++ b/commands/publish.js
@@ -47,7 +47,7 @@ function * run (context, heroku) {
   let headers = {}
 
   if (name.startsWith('heroku/')) {
-    let secondFactor = yield cli.prompt('Two-factor code', {mask: true});
+    let secondFactor = yield cli.prompt('Two-factor code', {mask: true})
     headers['Heroku-Two-Factor-Code'] = secondFactor
   }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
     "standard": "7.1.2",
     "unexpected": "10.15.0"
   },
+  "files": [
+    "/index.js",
+    "/commands",
+    "/lib"
+  ],
   "homepage": "https://github.com/heroku/heroku-buildkits",
   "keywords": [
     "heroku-plugin"


### PR DESCRIPTION
this attribute is now required in plugins otherwise a warning is displayed (though notably, the plugins still work fine with the warning)

See my blog post for the reason why this is now required: https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d

for other plugins, if you run `npm pack; tar -xvzf *.tgz; rm -rf package *.tgz` that will print the files it's currently packing